### PR TITLE
rework the taint logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@ kubectl apply -f manifest.yml
 kubectl -n node-taint-manager rollout status deployment node-taint-manager
 ```
 
-2. Configure taints for any required daemonsets.
+2. Configure taints to opt in nodes.
 
 ```
 taints:
 - key: "node.vanstee.github.io/daemonset-not-ready"
-  value: "calico-system.calico-node"
   effect: "NoSchedule"
 ```
 
@@ -43,12 +42,6 @@ tolerations:
 # ignore all daemonset-not-ready taints
 tolerations:
 - key: "node.vanstee.github.io/daemonset-not-ready"
-  operator: "Exists"
-
-# ignore specific daemonset-not-ready taint for this daemonset
-tolerations:
-- key: "node.vanstee.github.io/daemonset-not-ready"
-  value: "calico-system.calico-node"
   operator: "Exists"
 ```
 

--- a/main.go
+++ b/main.go
@@ -183,7 +183,7 @@ func main() {
 				}
 
 				// only proceed if all the tolerated daemonset pods on the node are ready
-				allPodsReady := false
+				allPodsReady := true
 				for _, ipod := range pods {
 					pod, ok := ipod.(*apiv1.Pod)
 					if !ok {
@@ -207,7 +207,6 @@ func main() {
 						allPodsReady = false
 						break
 					}
-					allPodsReady = true
 				}
 				if !allPodsReady {
 					continue

--- a/script/integration-test
+++ b/script/integration-test
@@ -19,7 +19,6 @@ nodes:
     nodeRegistration:
       taints:
       - key: "node.vanstee.github.io/daemonset-not-ready"
-        value: "kube-system.test-1"
         effect: "NoSchedule"
 EOF
 
@@ -45,6 +44,33 @@ spec:
     spec:
       containers:
       - name: test-1
+        image: alpine
+        command: ["/bin/sleep", "infinity"]
+        readinessProbe:
+          exec:
+            command:
+            - "/bin/true"
+      tolerations:
+      - key: "node.vanstee.github.io/daemonset-not-ready"
+        operator: "Exists"
+EOF
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: test-2
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      name: test-2
+  template:
+    metadata:
+      labels:
+        name: test-2
+    spec:
+      containers:
+      - name: test-2
         image: alpine
         command: ["/bin/sleep", "infinity"]
         readinessProbe:


### PR DESCRIPTION
There was previous incorrect assumptions about multiple taints with the same key being valid. That was incorrect, and would not work for cases with multiple daemonsets that need to be waited on.

This changes the structure so there is one big taint that all daemonsets must each become ready for. Once all daemonset pods are ready, that node then gets the taint removed, and regular scheduling can occur.

This is slightly less flexible than the previous design, but it fixes the previous assumptions for 2+ daemonsets cases.