### PR TITLE
feat: add custom labels on ready nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ kubectl apply -f manifest.yml
 kubectl -n node-taint-manager rollout status deployment node-taint-manager
 ```
 
+### Optional: Configure custom labels
+
+You can configure the node-taint-manager to add custom labels to nodes when their taints are removed. This is useful for marking nodes as ready or adding operational labels.
+
+#### Using environment variables in the deployment:
+
+```yaml
+env:
+- name: CUSTOM_LABELS
+  value: "node.kubernetes.io/ready=true,environment=production"
+```
+
+#### Label format:
+- Use `key=value` format for each label
+- Multiple labels can be separated by commas
+- Labels with forward slashes (like `node.kubernetes.io/ready`) are supported
+
 2. Configure taints to opt in nodes.
 
 ```

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestParseCustomLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected []LabelConfig
+	}{
+		{
+			name:     "empty environment variable",
+			envValue: "",
+			expected: []LabelConfig{},
+		},
+		{
+			name:     "unset environment variable",
+			envValue: "",
+			expected: []LabelConfig{},
+		},
+		{
+			name:     "single label",
+			envValue: "environment=production",
+			expected: []LabelConfig{
+				{Key: "environment", Value: "production"},
+			},
+		},
+		{
+			name:     "multiple labels",
+			envValue: "environment=production,team=platform,region=us-west",
+			expected: []LabelConfig{
+				{Key: "environment", Value: "production"},
+				{Key: "team", Value: "platform"},
+				{Key: "region", Value: "us-west"},
+			},
+		},
+		{
+			name:     "labels with spaces",
+			envValue: "environment = production , team = platform",
+			expected: []LabelConfig{
+				{Key: "environment", Value: "production"},
+				{Key: "team", Value: "platform"},
+			},
+		},
+		{
+			name:     "empty pairs are ignored",
+			envValue: "environment=production,,team=platform",
+			expected: []LabelConfig{
+				{Key: "environment", Value: "production"},
+				{Key: "team", Value: "platform"},
+			},
+		},
+		{
+			name:     "invalid format is ignored",
+			envValue: "environment=production,invalid,team=platform",
+			expected: []LabelConfig{
+				{Key: "environment", Value: "production"},
+				{Key: "team", Value: "platform"},
+			},
+		},
+		{
+			name:     "labels with special characters",
+			envValue: "app.kubernetes.io/name=myapp,app.kubernetes.io/version=v1.0.0",
+			expected: []LabelConfig{
+				{Key: "app.kubernetes.io/name", Value: "myapp"},
+				{Key: "app.kubernetes.io/version", Value: "v1.0.0"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable
+			if tt.envValue != "" {
+				os.Setenv("CUSTOM_LABELS", tt.envValue)
+			} else {
+				os.Unsetenv("CUSTOM_LABELS")
+			}
+
+			// Clean up after test
+			defer os.Unsetenv("CUSTOM_LABELS")
+
+			result := parseCustomLabels()
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("parseCustomLabels() returned %d items, want %d items", len(result), len(tt.expected))
+			} else if len(result) > 0 && !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("parseCustomLabels() = %v (type: %T), want %v (type: %T)", result, result, tt.expected, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseCustomLabelsWithInvalidFormats(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected []LabelConfig
+	}{
+		{
+			name:     "key-only format",
+			envValue: "key-only",
+			expected: []LabelConfig{},
+		},
+		{
+			name:     "value-only format",
+			envValue: "=value-only",
+			expected: []LabelConfig{
+				{Key: "", Value: "value-only"},
+			},
+		},
+		{
+			name:     "key=value=extra format",
+			envValue: "key=value=extra",
+			expected: []LabelConfig{
+				{Key: "key", Value: "value=extra"},
+			},
+		},
+		{
+			name:     "empty string",
+			envValue: "",
+			expected: []LabelConfig{},
+		},
+		{
+			name:     "whitespace only",
+			envValue: "   ",
+			expected: []LabelConfig{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("CUSTOM_LABELS", tt.envValue)
+			defer os.Unsetenv("CUSTOM_LABELS")
+
+			result := parseCustomLabels()
+
+			if len(result) != len(tt.expected) {
+				t.Errorf("parseCustomLabels() returned %d items, want %d items", len(result), len(tt.expected))
+			} else if len(result) > 0 && !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("parseCustomLabels() = %v (type: %T), want %v (type: %T)", result, result, tt.expected, tt.expected)
+			}
+		})
+	}
+}

--- a/manifest.yml
+++ b/manifest.yml
@@ -8,7 +8,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: node-taint-manager
-
   name: node-taint-manager
 spec:
   replicas: 1
@@ -21,12 +20,16 @@ spec:
         app: node-taint-manager
     spec:
       containers:
-      - name: node-taint-manager
-        image: node-taint-manager:latest
-        imagePullPolicy: Never
+        - name: node-taint-manager
+          image: node-taint-manager:latest
+          imagePullPolicy: Never
+          # Comment out and modify the following to add custom labels when taints are removed
+          env:
+            - name: CUSTOM_LABELS
+              value: "node.kubernetes.io/ready=true"
       serviceAccount: node-taint-manager
       tolerations:
-      - operator: "Exists"
+        - operator: "Exists"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -39,21 +42,22 @@ kind: ClusterRole
 metadata:
   name: node-taint-manager
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - "pods"
-  verbs:
-  - "list"
-  - "watch"
-- apiGroups:
-  - ""
-  resources:
-  - "nodes"
-  verbs:
-  - "list"
-  - "patch"
-  - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "list"
+      - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "nodes"
+    verbs:
+      - "list"
+      - "patch"
+      - "watch"
+      - "update"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -64,6 +68,6 @@ roleRef:
   name: node-taint-manager
   apiGroup: rbac.authorization.k8s.io
 subjects:
-- kind: ServiceAccount
-  name: node-taint-manager
-  namespace: node-taint-manager
+  - kind: ServiceAccount
+    name: node-taint-manager
+    namespace: node-taint-manager

--- a/script/integration-test
+++ b/script/integration-test
@@ -20,6 +20,8 @@ nodes:
       taints:
       - key: "node.vanstee.github.io/daemonset-not-ready"
         effect: "NoSchedule"
+      kubeletExtraArgs:
+        node-labels: "node.kubernetes.io/ready=false"
 EOF
 
 docker build -t node-taint-manager .
@@ -83,11 +85,11 @@ spec:
 EOF
 
 timeout 30s bash <<EOF
-while ! kubectl get node kind-worker -o json | jq -e '.spec.taints == null'; do
+while ! kubectl get node kind-worker -o json | jq -e '.spec.taints == null and .metadata.labels["node.kubernetes.io/ready"] == "true"'; do
 	sleep 1
 done
 
 echo "!!!"
-echo "!!! SUCCESS: taint was removed for ready daemonset pod"
+echo "!!! SUCCESS: taint was removed for ready daemonset pod and label was added"
 echo "!!!"
 EOF


### PR DESCRIPTION
# Purpose

Small feature for adding/modifying a label to nodes when they are untainted. This is useful if your metrics pipeline is pulling in node labels into metrics, because you can get more accurate data on when a node was truly available to schedule workloads onto. Good for SLOs regarding daemonset availability as well.